### PR TITLE
fix: 修复配置列表页面下载和上传文件功能url错误问题

### DIFF
--- a/src/pages/ConfigListPage.vue
+++ b/src/pages/ConfigListPage.vue
@@ -43,7 +43,7 @@
             </span>
             <span v-if="webResources.canUpdateConfig" class="query-button-item">
               <n-upload
-                action="/nacos/v1/console/config/import"
+                action="/rnacos/api/console/config/import"
                 :headers="uploadHeader"
                 :show-file-list="false"
                 @before-upload="doBeforeUpload"
@@ -367,7 +367,7 @@ export default defineComponent({
     download() {
       this.param.tenant = namespaceStore.current.value.namespaceId;
       var params = qs.stringify(this.param);
-      var url = '/nacos/v1/console/config/download?' + params;
+      var url = '/rnacos/api/console/config/download?' + params;
       this.$refs.download.setAttribute('href', url);
       return true;
     }


### PR DESCRIPTION
0.5.2版本配置列表页面上传和下载的url是错误的导致功能无法使用