### PR TITLE
feat: 配置列表增加批量删除和批量导出配置

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,13 +33,11 @@ const locale = langStore.current.value == 'zh' ? zhCN : enUS;
 </script>
 
 <template>
-  <n-config-provider
-    :theme-overrides="themeOverrides"
-    :locale="locale"
-    abstract
-  >
+  <n-config-provider :theme-overrides="themeOverrides" :locale="locale" abstract>
     <n-message-provider>
-      <router-view></router-view>
+      <n-dialog-provider>
+        <router-view />
+      </n-dialog-provider>
     </n-message-provider>
   </n-config-provider>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,7 +33,11 @@ const locale = langStore.current.value == 'zh' ? zhCN : enUS;
 </script>
 
 <template>
-  <n-config-provider :theme-overrides="themeOverrides" :locale="locale" abstract>
+  <n-config-provider
+    :theme-overrides="themeOverrides"
+    :locale="locale"
+    abstract
+  >
     <n-message-provider>
       <n-dialog-provider>
         <router-view />

--- a/src/i18n/lang/en-US.js
+++ b/src/i18n/lang/en-US.js
@@ -8,6 +8,8 @@ const message = {
     enabled: 'Enabled',
     disabled: 'Disabled',
     confirm: 'Confirm',
+    cancel: 'Cancel',
+    exit: 'Exit',
     title: 'Title',
     return: 'Return',
     back: 'Back',
@@ -33,7 +35,8 @@ const message = {
     permission: 'permission',
     submitSuccess: 'Submit success',
     success: 'Success',
-    home: 'Home'
+    home: 'Home',
+    batch: 'Batch'
   },
   cluster: {
     node: 'Node',
@@ -73,7 +76,11 @@ const message = {
     recover_history: 'Recover history',
     config_list: 'Config list',
     export_config: 'Export Config',
-    import_config: 'Import Config'
+    import_config: 'Import Config',
+    confirm_batch_delete_config_action: 'Are you sure you want to delete the selected <%:=count%> items?',
+    batch_delete: 'Batch delete',
+    batch_delete_success: 'Successfully deleted <%:=count%> items!',
+    selected_items: 'Selected <%:=count%> items',
   },
   client: {
     address: 'Client Address'

--- a/src/i18n/lang/en-US.js
+++ b/src/i18n/lang/en-US.js
@@ -77,10 +77,11 @@ const message = {
     config_list: 'Config list',
     export_config: 'Export Config',
     import_config: 'Import Config',
-    confirm_batch_delete_config_action: 'Are you sure you want to delete the selected <%:=count%> items?',
+    confirm_batch_delete_config_action:
+      'Are you sure you want to delete the selected <%:=count%> items?',
     batch_delete: 'Batch delete',
     batch_delete_success: 'Successfully deleted <%:=count%> items!',
-    selected_items: 'Selected <%:=count%> items',
+    selected_items: 'Selected <%:=count%> items'
   },
   client: {
     address: 'Client Address'

--- a/src/i18n/lang/zh-CN.js
+++ b/src/i18n/lang/zh-CN.js
@@ -81,7 +81,7 @@ const message = {
     import_config: '导入配置',
     confirm_batch_delete_config_action: '确定要删除选中的 <%:=count%> 项吗？',
     batch_delete: '批量删除',
-    bacth_delete_access: '成功删除 <%:=count%> 项！',
+    batch_delete_success: '成功删除 <%:=count%> 项！',
     selected_items: '已选 <%:=count%> 项',
   },
   namespace: {

--- a/src/i18n/lang/zh-CN.js
+++ b/src/i18n/lang/zh-CN.js
@@ -82,7 +82,7 @@ const message = {
     confirm_batch_delete_config_action: '确定要删除选中的 <%:=count%> 项吗？',
     batch_delete: '批量删除',
     batch_delete_success: '成功删除 <%:=count%> 项！',
-    selected_items: '已选 <%:=count%> 项',
+    selected_items: '已选 <%:=count%> 项'
   },
   namespace: {
     namespace: '命名空间',

--- a/src/i18n/lang/zh-CN.js
+++ b/src/i18n/lang/zh-CN.js
@@ -8,6 +8,8 @@ const message = {
     enabled: '正常',
     disabled: '失效',
     confirm: '确认',
+    cancel: '取消',
+    exit: '退出',
     title: '标题',
     return: '返回',
     back: '返回',
@@ -33,7 +35,8 @@ const message = {
     permission: '权限',
     submitSuccess: '提交成功',
     success: '成功',
-    home: '首页'
+    home: '首页',
+    batch: '批量'
   },
   cluster: {
     node: '节点',
@@ -75,11 +78,15 @@ const message = {
     recover_history: '恢复历史记录',
     config_list: '配置列表',
     export_config: '导出配置',
-    import_config: '导入配置'
+    import_config: '导入配置',
+    confirm_batch_delete_config_action: '确定要删除选中的 <%:=count%> 项吗？',
+    batch_delete: '批量删除',
+    bacth_delete_access: '成功删除 <%:=count%> 项！',
+    selected_items: '已选 <%:=count%> 项',
   },
   namespace: {
     namespace: '命名空间',
-    the_namespace_id_has_been_copied: '已复制命名空间id!',
+    the_namespace_id_has_been_copied: '已复制命名空间id！',
     namespaceName: '命名空间名称',
     namespaceId: '命名空间Id',
     new_namespace: '创建命名空间',
@@ -204,9 +211,9 @@ const message = {
     need_password: '需要输入密码',
     need_captcha: '需要输入验证码',
     get_captcha_fail: '获取验证码失败',
-    USER_CHECK_ERROR: '登录失败，用户名或密码错误!',
-    CAPTCHA_CHECK_ERROR: '验证码校验不通过!',
-    LOGIN_LIMITE_ERROR: '登录校验太频繁，稍后再试!',
+    USER_CHECK_ERROR: '登录失败，用户名或密码错误！',
+    CAPTCHA_CHECK_ERROR: '验证码校验不通过！',
+    LOGIN_LIMITE_ERROR: '登录校验太频繁，稍后再试！',
     LOGIN_UNKNOWN_ERROR: '登录失败，未知错误'
   },
   about: {
@@ -214,7 +221,7 @@ const message = {
     intro_p01:
       'r-nacos是一个用rust实现的nacos服务。相较于java nacos来说，是一个提供相同功能，启动更快、占用系统资源更小（初始内存小于10M）、性能更高、运行更稳定的服务。',
     intro_p02:
-      'r-nacos设计上完全兼容最新版本nacos面向client sdk 的协议（包含1.x的http OpenApi，和2.x的grpc协议）,支持使用nacos服务的应用平迁到 r-nacos。',
+      'r-nacos设计上完全兼容最新版本nacos面向client sdk 的协议（包含1.x的http OpenApi，和2.x的grpc协议），支持使用nacos服务的应用平迁到 r-nacos。',
     intro_p03: '使用过程有什么问题可以到 github提issue。',
     version_title: '系统版本号',
     user_title: '当前用户'

--- a/src/pages/ConfigListPage.vue
+++ b/src/pages/ConfigListPage.vue
@@ -48,7 +48,7 @@
                 <n-space justify="end" class="ml-2">
                   <n-button tertiary @click="queryList">{{
                     this.$t('common.query')
-                    }}</n-button>
+                  }}</n-button>
                   <n-button
                     v-if="webResources.canUpdateConfig"
                     type="info"
@@ -58,7 +58,7 @@
 
                   <n-button @click="download" type="info">{{
                     this.$t('config.export_config')
-                    }}</n-button>
+                  }}</n-button>
 
                   <n-upload
                     v-if="webResources.canUpdateConfig"
@@ -70,7 +70,7 @@
                   >
                     <n-button type="info">{{
                       this.$t('config.import_config')
-                      }}</n-button>
+                    }}</n-button>
                   </n-upload>
                 </n-space>
               </n-gi>
@@ -82,16 +82,31 @@
             <n-button type="info" size="tiny" @click="toggleBatchMode">
               {{ isBatchModeRef ? t('common.exit') : t('common.batch') }}
             </n-button>
-            <n-button v-if="isBatchModeRef" tertiary size="tiny" :disabled="checkedRowKeysRef.length === 0"
-              @click="checkedRowKeysRef = []">
+            <n-button
+              v-if="isBatchModeRef"
+              tertiary
+              size="tiny"
+              :disabled="checkedRowKeysRef.length === 0"
+              @click="checkedRowKeysRef = []"
+            >
               {{ t('common.cancel') }}
             </n-button>
-            <n-button v-if="isBatchModeRef" type="info" size="tiny" :disabled="checkedRowKeysRef.length === 0"
-              @click="batchDownload">
+            <n-button
+              v-if="isBatchModeRef"
+              type="info"
+              size="tiny"
+              :disabled="checkedRowKeysRef.length === 0"
+              @click="batchDownload"
+            >
               {{ t('config.export_config') }}
             </n-button>
-            <n-button v-if="isBatchModeRef" type="error" size="tiny" :disabled="checkedRowKeysRef.length === 0"
-              @click="batchRemove">
+            <n-button
+              v-if="isBatchModeRef"
+              type="error"
+              size="tiny"
+              :disabled="checkedRowKeysRef.length === 0"
+              @click="batchRemove"
+            >
               {{ t('common.delete') }}
             </n-button>
           </div>
@@ -99,9 +114,19 @@
             {{ selectedText }}
           </div>
         </div>
-        <n-data-table remote ref="table" :scroll-x="600" :bordered="false" :columns="computedColumns" :data="data"
-          :loading="loading" :pagination="pagination" :row-key="rowKey" v-model:checked-row-keys="checkedRowKeysRef"
-          @update:page="handlePageChange" />
+        <n-data-table
+          remote
+          ref="table"
+          :scroll-x="600"
+          :bordered="false"
+          :columns="computedColumns"
+          :data="data"
+          :loading="loading"
+          :pagination="pagination"
+          :row-key="rowKey"
+          v-model:checked-row-keys="checkedRowKeysRef"
+          @update:page="handlePageChange"
+        />
       </div>
     </div>
 
@@ -117,8 +142,8 @@
         :title="getDetailTitle"
         :submitName="
           model.mode === constant.FORM_MODE_CREATE
-        ? t('common.confirm')
-        : t('config.confirm_change')
+            ? t('common.confirm')
+            : t('config.confirm_change')
         "
         @close="closeForm"
         @submit="submitForm"
@@ -173,7 +198,7 @@ import {
 import { useProjectSettingStore } from '@/store/modules/projectSetting';
 import { useDialog } from 'naive-ui';
 import template from 'template_js';
-import axios from "axios";
+import axios from 'axios';
 
 export default defineComponent({
   components: {
@@ -181,7 +206,7 @@ export default defineComponent({
     Close,
     SubContentFullPage,
     ConfigDetail,
-    DiffComponent,
+    DiffComponent
   },
   setup() {
     const checkedRowKeysRef = ref([]);
@@ -208,7 +233,7 @@ export default defineComponent({
       dialog.warning({
         title: t('config.batch_delete'),
         content: template(t('config.confirm_batch_delete_config_action'), {
-          count: checkedRowKeysRef.value.length,
+          count: checkedRowKeysRef.value.length
         }),
         positiveButtonProps: {
           type: 'primary'
@@ -225,12 +250,12 @@ export default defineComponent({
                   group,
                   dataId
                 })
-                .then(handleApiResult)
+                .then(handleApiResult);
             }
 
             window.$message.success(
               template(t('config.batch_delete_success'), {
-                count: checkedRowKeysRef.value.length,
+                count: checkedRowKeysRef.value.length
               })
             );
 
@@ -409,20 +434,19 @@ export default defineComponent({
 
     const computedColumns = computed(() => {
       if (isBatchModeRef.value) {
-        return [
-          { type: 'selection', width: 48 },
-          ...columns
-        ];
+        return [{ type: 'selection', width: 48 }, ...columns];
       }
       return columns;
     });
 
     const selectedText = computed(() =>
-      template(t('config.selected_items'), { count: checkedRowKeysRef.value.length })
+      template(t('config.selected_items'), {
+        count: checkedRowKeysRef.value.length
+      })
     );
 
     async function batchDownload() {
-      const body = checkedRowKeysRef.value.map(key => {
+      const body = checkedRowKeysRef.value.map((key) => {
         const [group, dataId] = key.split('@@');
         return {
           tenant: namespaceStore.current.value.namespaceId,
@@ -432,17 +456,17 @@ export default defineComponent({
       });
 
       const response = await axios.post(
-        "/rnacos/api/console/config/download",
+        '/rnacos/api/console/config/download',
         body,
         {
-          responseType: "blob"
+          responseType: 'blob'
         }
       );
 
-      const blob = new Blob([response.data], { type: "application/zip" });
+      const blob = new Blob([response.data], { type: 'application/zip' });
       const url = window.URL.createObjectURL(blob);
 
-      const link = document.createElement("a");
+      const link = document.createElement('a');
       link.href = url;
       link.download = `rnacos_config_export_${Date.now()}.zip`;
       link.click();
@@ -492,7 +516,6 @@ export default defineComponent({
       selectedText,
       batchDownload
     };
-
   },
   computed: {
     getTenant() {

--- a/src/pages/ConfigListPage.vue
+++ b/src/pages/ConfigListPage.vue
@@ -77,18 +77,27 @@
             </n-grid>
           </n-form>
         </n-card>
-        <n-data-table
-          remote
-          ref="table"
-          :scroll-x="600"
-          :bordered="false"
-          :columns="columns"
-          :data="data"
-          :loading="loading"
-          :pagination="pagination"
-          :row-key="rowKey"
-          @update:page="handlePageChange"
-        />
+        <div class="flex justify-between items-center mb-2 px-4">
+          <div class="flex items-center gap-2">
+            <n-button type="info" size="tiny" @click="toggleBatchMode">
+              {{ isBatchModeRef ? t('common.exit') : t('common.batch') }}
+            </n-button>
+            <n-button v-if="isBatchModeRef" tertiary size="tiny" :disabled="checkedRowKeysRef.length === 0"
+              @click="checkedRowKeysRef = []">
+              {{ t('common.cancel') }}
+            </n-button>
+            <n-button v-if="isBatchModeRef" type="error" size="tiny" :disabled="checkedRowKeysRef.length === 0"
+              @click="batchRemove">
+              {{ t('common.delete') }}
+            </n-button>
+          </div>
+          <div v-if="isBatchModeRef">
+            {{ selectedText }}
+          </div>
+        </div>
+        <n-data-table remote ref="table" :scroll-x="600" :bordered="false" :columns="computedColumns" :data="data"
+          :loading="loading" :pagination="pagination" :row-key="rowKey" v-model:checked-row-keys="checkedRowKeysRef"
+          @update:page="handlePageChange" />
       </div>
     </div>
 
@@ -104,8 +113,8 @@
         :title="getDetailTitle"
         :submitName="
           model.mode === constant.FORM_MODE_CREATE
-            ? t('common.confirm')
-            : t('config.confirm_change')
+        ? t('common.confirm')
+        : t('config.confirm_change')
         "
         @close="closeForm"
         @submit="submitForm"
@@ -158,6 +167,8 @@ import {
   printApiSuccess
 } from '@/utils/request';
 import { useProjectSettingStore } from '@/store/modules/projectSetting';
+import { useDialog } from 'naive-ui';
+import template from 'template_js';
 
 export default defineComponent({
   components: {
@@ -165,9 +176,69 @@ export default defineComponent({
     Close,
     SubContentFullPage,
     ConfigDetail,
-    DiffComponent
+    DiffComponent,
   },
   setup() {
+    const checkedRowKeysRef = ref([]);
+    const isBatchModeRef = ref(false);
+    function toggleBatchMode() {
+      isBatchModeRef.value = !isBatchModeRef.value;
+      if (!isBatchModeRef.value) {
+        checkedRowKeysRef.value = [];
+      }
+    }
+    const rowKey = (rowData) => rowData.group + '@@' + rowData.dataId;
+
+    const toggleSelectAll = (checked) => {
+      if (checked) {
+        checkedRowKeysRef.value = dataRef.value.map(rowKey);
+      } else {
+        checkedRowKeysRef.value = [];
+      }
+    };
+
+    const dialog = useDialog();
+    const batchRemove = () => {
+      if (checkedRowKeysRef.value.length === 0) return;
+      dialog.warning({
+        title: t('config.batch_delete'),
+        content: template(t('config.confirm_batch_delete_config_action'), {
+                  count: checkedRowKeysRef.value.length,
+                }),
+        positiveButtonProps: {
+          type: 'primary'
+        },
+        positiveText: t('common.confirm'),
+        negativeText: t('common.cancel'),
+        onPositiveClick: async () => {
+          try {
+            for (const key of checkedRowKeysRef.value) {
+              const [group, dataId] = key.split('@@');
+              await configApi
+                .removeConfigV2({
+                  tenant: namespaceStore.current.value.namespaceId,
+                  group,
+                  dataId
+                })
+                .then(handleApiResult)
+            }
+
+            window.$message.success(
+              template(t('config.bacth_delete_access'), {
+                count: checkedRowKeysRef.value.length,
+              })
+            );
+
+            checkedRowKeysRef.value = [];
+            doHandlePageChange(1);
+            toggleBatchMode();
+          } catch (error) {
+            printApiError(error);
+          }
+        }
+      });
+    };
+
     const { t } = useI18n();
     const projectSettingStore = useProjectSettingStore();
     let router = useRouter();
@@ -233,6 +304,7 @@ export default defineComponent({
         doQueryList()
           .then(handleApiResult)
           .then((page) => {
+            console.log('page response:', page);
             loadingRef.value = false;
             let count = page.totalCount;
             let pageSize = paginationReactive.pageSize;
@@ -330,8 +402,23 @@ export default defineComponent({
       removeItem,
       webResources
     );
+
+    const computedColumns = computed(() => {
+      if (isBatchModeRef.value) {
+        return [
+          { type: 'selection', width: 48 },
+          ...columns
+        ];
+      }
+      return columns;
+    });
+
+    const selectedText = computed(() =>
+      template(t('config.selected_items'), { count: checkedRowKeysRef.value.length })
+    );
+
     return {
-      columns,
+      computedColumns,
       webResources,
       data: dataRef,
       useForm: useFormRef,
@@ -347,9 +434,7 @@ export default defineComponent({
       constant,
       t,
       isMobile: computed(() => projectSettingStore.getIsMobile),
-      rowKey(rowData) {
-        return rowData.group + '@@' + rowData.dataId;
-      },
+      rowKey,
       doQueryList,
       doHandlePageChange,
       handlerUploadFinish({ event }) {
@@ -359,8 +444,15 @@ export default defineComponent({
         } else {
           window.$message.error('上传处理失败');
         }
-      }
+      },
+      checkedRowKeysRef,
+      toggleSelectAll,
+      batchRemove,
+      toggleBatchMode,
+      isBatchModeRef,
+      selectedText
     };
+
   },
   computed: {
     getTenant() {


### PR DESCRIPTION
### 1. 批量删除
仅支持勾选当前页面所有项，前端循环调用 console/v2/config/remove
<img width="760" alt="image" src="https://github.com/user-attachments/assets/4edf6b86-0f4e-47da-94ba-2d50f0aa8c9f" />
<img width="761" alt="image" src="https://github.com/user-attachments/assets/9f897e3f-07c6-4d49-9d36-feef89d44b28" />
### 2. 批量导出
<img width="766" alt="image" src="https://github.com/user-attachments/assets/923f7f50-c159-4a8a-9c44-746106bf89f5" />

Refs https://github.com/nacos-group/r-nacos/issues/212

